### PR TITLE
feat: add `partitioned` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,10 @@ export function serialize(
     }
   }
 
+  if (opt.partitioned) {
+    str += "; Partitioned"
+  }
+
   return str;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,17 +150,21 @@ export function serialize(
         : opt.priority;
 
     switch (priority) {
-      case "low":
+      case "low": {
         str += "; Priority=Low";
         break;
-      case "medium":
+      }
+      case "medium": {
         str += "; Priority=Medium";
         break;
-      case "high":
+      }
+      case "high": {
         str += "; Priority=High";
         break;
-      default:
+      }
+      default: {
         throw new TypeError("option priority is invalid");
+      }
     }
   }
 
@@ -171,25 +175,30 @@ export function serialize(
         : opt.sameSite;
 
     switch (sameSite) {
-      case true:
+      case true: {
         str += "; SameSite=Strict";
         break;
-      case "lax":
+      }
+      case "lax": {
         str += "; SameSite=Lax";
         break;
-      case "strict":
+      }
+      case "strict": {
         str += "; SameSite=Strict";
         break;
-      case "none":
+      }
+      case "none": {
         str += "; SameSite=None";
         break;
-      default:
+      }
+      default: {
         throw new TypeError("option sameSite is invalid");
+      }
     }
   }
 
   if (opt.partitioned) {
-    str += "; Partitioned"
+    str += "; Partitioned";
   }
 
   return str;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,10 +109,10 @@ export interface CookieSerializeOptions {
    */
   secure?: boolean | undefined;
   /**
-   * Cookies Having Independent Partitioned State (CHIPS, also known as Partitioned cookies) 
-   * allows developers to opt a cookie into partitioned storage, with a separate 
+   * Cookies Having Independent Partitioned State (CHIPS, also known as Partitioned cookies)
+   * allows developers to opt a cookie into partitioned storage, with a separate
    * cookie jar per top-level site.
-   * 
+   *
    * @see https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies
    */
   partitioned?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,11 +109,14 @@ export interface CookieSerializeOptions {
    */
   secure?: boolean | undefined;
   /**
-   * Cookies Having Independent Partitioned State (CHIPS, also known as Partitioned cookies)
-   * allows developers to opt a cookie into partitioned storage, with a separate
-   * cookie jar per top-level site.
+   * Specifies the `boolean` value for the [`Partitioned` `Set-Cookie`](rfc-cutler-httpbis-partitioned-cookies)
+   * attribute. When truthy, the `Partitioned` attribute is set, otherwise it is not. By default, the
+   * `Partitioned` attribute is not set.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies
+   * **note** This is an attribute that has not yet been fully standardized, and may change in the future.
+   * This also means many clients may ignore this attribute until they understand it.
+   *
+   * More information about can be found in [the proposal](https://github.com/privacycg/CHIPS)
    */
   partitioned?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,14 @@ export interface CookieSerializeOptions {
    * not have an HTTPS connection.
    */
   secure?: boolean | undefined;
+  /**
+   * Cookies Having Independent Partitioned State (CHIPS, also known as Partitioned cookies) 
+   * allows developers to opt a cookie into partitioned storage, with a separate 
+   * cookie jar per top-level site.
+   * 
+   * @see https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies
+   */
+  partitioned?: boolean;
 }
 
 /**

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -261,4 +261,14 @@ describe("serialize(name, value, options)", () => {
       expect(serialize("foo", "bar", { secure: false })).toBe("foo=bar");
     });
   });
+
+  describe('with "partitioned" option', () => {
+    it("should include partitioned flag when true", () => {
+      expect(serialize("foo", "bar", { partitioned: true })).toBe("foo=bar; Partitioned");
+    });
+
+    it("should not include partitioned flag when false", () => {
+      expect(serialize("foo", "bar", { partitioned: false })).toBe("foo=bar");
+    });
+  });
 });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -265,7 +265,7 @@ describe("serialize(name, value, options)", () => {
   describe('with "partitioned" option', () => {
     it("should include partitioned flag when true", () => {
       expect(serialize("foo", "bar", { partitioned: true })).toBe(
-        "foo=bar; Partitioned"
+        "foo=bar; Partitioned",
       );
     });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -264,7 +264,9 @@ describe("serialize(name, value, options)", () => {
 
   describe('with "partitioned" option', () => {
     it("should include partitioned flag when true", () => {
-      expect(serialize("foo", "bar", { partitioned: true })).toBe("foo=bar; Partitioned");
+      expect(serialize("foo", "bar", { partitioned: true })).toBe(
+        "foo=bar; Partitioned"
+      );
     });
 
     it("should not include partitioned flag when false", () => {


### PR DESCRIPTION
Spec: https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies

- Added `partitioned` option to cookie serialization. 
- Added tests and run lint:fix