### PR TITLE
feat: decode callback parameter adds key

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "pnpm lint && vitest run --coverage"
   },
   "devDependencies": {
+    "@types/node": "^20.12.12",
     "@vitest/coverage-v8": "^1.5.1",
     "automd": "^0.3.7",
     "changelogen": "^0.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^20.12.12
+        version: 20.12.12
       '@vitest/coverage-v8':
         specifier: ^1.5.1
-        version: 1.5.1(vitest@1.5.1)
+        version: 1.5.1(vitest@1.5.1(@types/node@20.12.12))
       automd:
         specifier: ^0.3.7
         version: 0.3.7
@@ -34,7 +37,7 @@ importers:
         version: 2.0.0(typescript@5.4.5)
       vitest:
         specifier: ^1.5.1
-        version: 1.5.1
+        version: 1.5.1(@types/node@20.12.12)
 
 packages:
 
@@ -516,30 +519,35 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.4.1':
     resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.4.1':
     resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.4.1':
     resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.4.1':
     resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.4.1':
     resolution: {integrity: sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==}
@@ -646,36 +654,43 @@ packages:
     resolution: {integrity: sha512-L1+D8/wqGnKQIlh4Zre9i4R4b4noxzH5DDciyahX4oOz62CphY7WDWqJoQ66zNR4oScLNOqQJfNSIAe/6TPUmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.13.2':
     resolution: {integrity: sha512-tK5eoKFkXdz6vjfkSTCupUzCo40xueTOiOO6PeEIadlNBkadH1wNOH8ILCPIl8by/Gmb5AGAeQOFeLev7iZDOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.13.2':
     resolution: {integrity: sha512-zvXvAUGGEYi6tYhcDmb9wlOckVbuD+7z3mzInCSTACJ4DQrdSLPNUeDIcAQW39M3q6PDquqLWu7pnO39uSMRzQ==}
     cpu: [ppc64le]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.13.2':
     resolution: {integrity: sha512-C3GSKvMtdudHCN5HdmAMSRYR2kkhgdOfye4w0xzyii7lebVr4riCgmM6lRiSCnJn2w1Xz7ZZzHKuLrjx5620kw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.13.2':
     resolution: {integrity: sha512-l4U0KDFwzD36j7HdfJ5/TveEQ1fUTjFFQP5qIt9gBqBgu1G8/kCaq5Ok05kd5TG9F8Lltf3MoYsUMw3rNlJ0Yg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.13.2':
     resolution: {integrity: sha512-xXMLUAMzrtsvh3cZ448vbXqlUa7ZL8z0MwHp63K2IIID2+DeP5iWIT6g1SN7hg1VxPzqx0xZdiDM9l4n9LRU1A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.13.2':
     resolution: {integrity: sha512-M/JYAWickafUijWPai4ehrjzVPKRCyDb1SLuO+ZyPfoXgeCEAlgPkNXewFZx0zcnoIe3ay4UjXIMdXQXOZXWqA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.13.2':
     resolution: {integrity: sha512-2YWwoVg9KRkIKaXSh0mz3NmfurpmYoBBTAXA9qt7VXk0Xy12PoOP40EFuau+ajgALbbhi4uTj3tSG3tVseCjuA==}
@@ -711,6 +726,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/node@20.12.12':
+    resolution: {integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2731,6 +2749,9 @@ packages:
       typescript:
         optional: true
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -3372,6 +3393,10 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node@20.12.12':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/resolve@1.20.2': {}
@@ -3464,7 +3489,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitest/coverage-v8@1.5.1(vitest@1.5.1)':
+  '@vitest/coverage-v8@1.5.1(vitest@1.5.1(@types/node@20.12.12))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -3479,7 +3504,7 @@ snapshots:
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 6.0.0
-      vitest: 1.5.1
+      vitest: 1.5.1(@types/node@20.12.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -5718,6 +5743,8 @@ snapshots:
       - sass
       - supports-color
 
+  undici-types@5.26.5: {}
+
   unicorn-magic@0.1.0: {}
 
   universalify@2.0.1: {}
@@ -5753,13 +5780,13 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite-node@1.5.1:
+  vite-node@1.5.1(@types/node@20.12.12):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.7
+      vite: 5.2.7(@types/node@20.12.12)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5770,15 +5797,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.2.7:
+  vite@5.2.7(@types/node@20.12.12):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.13.2
     optionalDependencies:
+      '@types/node': 20.12.12
       fsevents: 2.3.3
 
-  vitest@1.5.1:
+  vitest@1.5.1(@types/node@20.12.12):
     dependencies:
       '@vitest/expect': 1.5.1
       '@vitest/runner': 1.5.1
@@ -5797,9 +5825,11 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.6.0
       tinypool: 0.8.3
-      vite: 5.2.7
-      vite-node: 1.5.1
+      vite: 5.2.7(@types/node@20.12.12)
+      vite-node: 1.5.1(@types/node@20.12.12)
       why-is-node-running: 2.2.2
+    optionalDependencies:
+      '@types/node': 20.12.12
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,7 @@ function isDate(val) {
  */
 function tryDecode(str, decode, key) {
   try {
-    return decode.length == 2 ? decode(str, key) : decode(str)
+    return decode.length === 2 ? decode(str, key) : decode(str)
   } catch {
     return str;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,7 @@ function isDate(val) {
  */
 function tryDecode(str, decode, key) {
   try {
-    return decode.length === 2 ? decode(str, key) : decode(str)
+    return decode.length === 2 ? decode(str, key) : decode(str);
   } catch {
     return str;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export function parse(
         val = val.slice(1, -1);
       }
 
-      obj[key] = tryDecode(val, dec);
+      obj[key] = tryDecode(val, dec, key);
     }
 
     index = endIdx + 1;
@@ -220,14 +220,14 @@ function isDate(val) {
 
 /**
  * Try decoding a string using a decoding function.
- *
  * @param {string} str
  * @param {function} decode
+ * @param {string} [key]
  * @private
  */
-function tryDecode(str, decode) {
+function tryDecode(str, decode, key) {
   try {
-    return decode(str);
+    return decode.length == 2 ? decode(str, key) : decode(str)
   } catch {
     return str;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,8 @@ export interface CookieParseOptions {
    *
    * *Note* if an error is thrown from this function, the original, non-decoded
    * cookie value will be returned as the cookie's value.
+   * 
+   * *Explain*: callback key is added to facilitate upper-layer filtering of decode
    */
-  decode?(value: string): string;
+  decode?(value: string, key?: string): string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,7 @@ export interface CookieParseOptions {
    *
    * *Note* if an error is thrown from this function, the original, non-decoded
    * cookie value will be returned as the cookie's value.
-   * 
+   *
    * *Explain*: callback key is added to facilitate upper-layer filtering of decode
    */
   decode?(value: string, key?: string): string;

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -63,7 +63,8 @@ describe("cookie.parse(str, options)", () => {
     it("should specify alternative value decoder", () => {
       expect(
         parse('foo="YmFy"', {
-          decode: (v) => {
+          decode: (v, k) => {
+            expect(k).toBe("foo");
             return Buffer.from(v, "base64").toString();
           },
         }),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Relate issuse：[Decode function for useCookie called for every cookie present](https://github.com/nuxt/nuxt/issues/27246)

Example：
![image](https://github.com/unjs/cookie-es/assets/9338717/e05c6dca-0957-4ab4-8366-ca8e0767b408)

Reason：
![image](https://github.com/unjs/cookie-es/assets/9338717/6d401214-2007-47a2-a9e5-7e1a9dca54cb)
![image](https://github.com/unjs/cookie-es/assets/9338717/5004dfa7-a453-410d-b11f-9c06e895737f)

When useCookie('bar',..), document.cookie = "foo=FOO; bar=BAR", the parse function will traverse each cookie and then decode As a result, foo cookie will also call barCookie decode, which is unreasonable. So my idea is to return one more key field when parse, so that the upper layer can filter out the decode that does not belong to the current key.


 
