### PR TITLE
docs: fix links for `partitioned` attribute of `CookieSerializeOptions`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,7 @@ export interface CookieSerializeOptions {
    * **note** This is an attribute that has not yet been fully standardized, and may change in the future.
    * This also means many clients may ignore this attribute until they understand it.
    *
-   * More information can be found in {@link https://github.com/privacycg/CHIPS|the proposal}.
+   * More information can be found in the {@link https://github.com/privacycg/CHIPS|proposal}.
    */
   partitioned?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,14 +109,14 @@ export interface CookieSerializeOptions {
    */
   secure?: boolean | undefined;
   /**
-   * Specifies the `boolean` value for the {@link https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies#section-2.1|`Partitioned` `Set-Cookie`}
+   * Specifies the `boolean` value for the [`Partitioned` `Set-Cookie`](https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies#section-2.1)
    * attribute. When truthy, the `Partitioned` attribute is set, otherwise it is not. By default, the
    * `Partitioned` attribute is not set.
    *
    * **note** This is an attribute that has not yet been fully standardized, and may change in the future.
    * This also means many clients may ignore this attribute until they understand it.
    *
-   * More information can be found in the {@link https://github.com/privacycg/CHIPS|proposal}.
+   * More information can be found in the [https://github.com/privacycg/CHIPS](proposal).
    */
   partitioned?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,14 +109,14 @@ export interface CookieSerializeOptions {
    */
   secure?: boolean | undefined;
   /**
-   * Specifies the `boolean` value for the [`Partitioned` `Set-Cookie`](rfc-cutler-httpbis-partitioned-cookies)
+   * Specifies the `boolean` value for the {@link https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies#section-2.1|`Partitioned` `Set-Cookie`}
    * attribute. When truthy, the `Partitioned` attribute is set, otherwise it is not. By default, the
    * `Partitioned` attribute is not set.
    *
    * **note** This is an attribute that has not yet been fully standardized, and may change in the future.
    * This also means many clients may ignore this attribute until they understand it.
    *
-   * More information about can be found in [the proposal](https://github.com/privacycg/CHIPS)
+   * More information can be found in {@link https://github.com/privacycg/CHIPS|the proposal}.
    */
   partitioned?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,7 @@ export interface CookieSerializeOptions {
    * **note** This is an attribute that has not yet been fully standardized, and may change in the future.
    * This also means many clients may ignore this attribute until they understand it.
    *
-   * More information can be found in the [https://github.com/privacycg/CHIPS](proposal).
+   * More information can be found in the [proposal](https://github.com/privacycg/CHIPS).
    */
   partitioned?: boolean;
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/27297#discussion_r1609039615

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Links were having incorrect format.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
