### PR TITLE
fix: parse filter code lose

### DIFF
--- a/src/cookie/parse.ts
+++ b/src/cookie/parse.ts
@@ -43,6 +43,10 @@ export function parse(
     }
 
     const key = str.slice(index, eqIdx).trim();
+    if (opt?.filter && !opt?.filter(key)) {
+      index = endIdx + 1;
+      continue;
+    }
 
     // only assign once
     if (undefined === obj[key as keyof typeof obj]) {

--- a/test/cookie-parse.test.ts
+++ b/test/cookie-parse.test.ts
@@ -80,9 +80,9 @@ describe("cookie.parse(str, options)", () => {
         parse("a=1;b=2", {
           filter: (key) => key === "a",
         }),
-      ).toMatchObject({ a: "1" });
+      ).toEqual({ a: "1" });
 
-      expect(parse("a=1;b=2")).toMatchObject({ a: "1", b: "2" });
+      expect(parse("a=1;b=2")).toEqual({ a: "1", b: "2" });
     });
   });
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

There are two problems
1. Parse refactor，parse filter code lose 
2. The test case asserts api usage errors, causing the test case to not execute correctly

