### PR TITLE
feat(options): add allowMultiple to options

### DIFF
--- a/src/cookie/types.ts
+++ b/src/cookie/types.ts
@@ -142,4 +142,8 @@ export interface CookieParseOptions {
    * Custom function to filter parsing specific keys.
    */
   filter?(key: string): boolean;
+   /**
+   * Flag to allow to return multiple values when cookie is duplicated.
+   */
+   allowMultiple?: boolean;
 }

--- a/test/cookie-parse.test.ts
+++ b/test/cookie-parse.test.ts
@@ -61,6 +61,21 @@ describe("cookie.parse(str)", () => {
       bar: "bar",
     });
   });
+
+  it("should return duplicated cookies values if `allowMultiple` is set", () => {
+    expect(parse("foo=%1;bar=bar;foo=boo", { allowMultiple: true })).toMatchObject({
+      foo: ["%1","boo"],
+      bar: "bar",
+    });
+    expect(parse("foo=false;bar=bar;foo=true", { allowMultiple: true })).toMatchObject({
+      foo: ["false","true"],
+      bar: "bar",
+    });
+    expect(parse("foo=;bar=bar;foo=boo", { allowMultiple: true })).toMatchObject({
+      foo: ["","boo"],
+      bar: "bar",
+    });
+  });
 });
 
 describe("cookie.parse(str, options)", () => {


### PR DESCRIPTION
Specifies a boolean flag (`allowMultiple`) which if set to `true` allows reading multiple cookies with same name (key) and returning values in an array.

closes #51 

