### PR TITLE
feat: add `decodeName` option to `parse()`

### DIFF
--- a/src/cookie/parse.ts
+++ b/src/cookie/parse.ts
@@ -45,7 +45,8 @@ export function parse(str: string, options?: CookieParseOptions): Cookies | Mult
       continue;
     }
 
-    const key = valueSlice(str, index, eqIdx);
+    const rawKey = valueSlice(str, index, eqIdx);
+    const key = options?.decodeName ? options.decodeName(rawKey) : rawKey;
 
     if (options?.filter && !options.filter(key)) {
       index = endIdx + 1;

--- a/src/cookie/types.ts
+++ b/src/cookie/types.ts
@@ -20,18 +20,14 @@ export interface CookieParseOptions {
   decode?: (str: string) => string | undefined;
 
   /**
-   * Specifies a function that will be used to decode a cookie-name.
-   *
-   * Browsers may URL-encode special characters in cookie names (e.g. `@` becomes `%40`).
-   * By default, cookie names are returned as-is from the `Cookie` header. Use this option
-   * to decode them — for example, with `decodeURIComponent`.
-   *
-   * @default undefined (no decoding)
+   * Custom function to decode cookie names. By default, names are not decoded.
+   * Errors are not caught — if your function can throw, wrap it in a try/catch.
    */
   decodeName?: (str: string) => string;
 
   /**
    * Custom function to filter parsing specific keys.
+   * When used with `decodeName`, receives the decoded name.
    */
   filter?(key: string): boolean;
 

--- a/src/cookie/types.ts
+++ b/src/cookie/types.ts
@@ -20,6 +20,17 @@ export interface CookieParseOptions {
   decode?: (str: string) => string | undefined;
 
   /**
+   * Specifies a function that will be used to decode a cookie-name.
+   *
+   * Browsers may URL-encode special characters in cookie names (e.g. `@` becomes `%40`).
+   * By default, cookie names are returned as-is from the `Cookie` header. Use this option
+   * to decode them — for example, with `decodeURIComponent`.
+   *
+   * @default undefined (no decoding)
+   */
+  decodeName?: (str: string) => string;
+
+  /**
    * Custom function to filter parsing specific keys.
    */
   filter?(key: string): boolean;

--- a/test/cookie-parse.test.ts
+++ b/test/cookie-parse.test.ts
@@ -87,6 +87,44 @@ describe("cookie.parse(str, options)", () => {
       ).toMatchObject({ foo: "bar" });
     });
 
+  });
+
+  describe('with "decodeName" option', () => {
+    it("should decode URL-encoded cookie names", () => {
+      expect(
+        parse("user%40test.local=bar", {
+          decodeName: decodeURIComponent,
+        }),
+      ).toMatchObject({ "user@test.local": "bar" });
+    });
+
+    it("should not affect names without encoding", () => {
+      expect(
+        parse("foo=bar", {
+          decodeName: decodeURIComponent,
+        }),
+      ).toMatchObject({ foo: "bar" });
+    });
+
+    it("should decode names and values independently", () => {
+      expect(
+        parse("user%40host=val%20ue", {
+          decodeName: decodeURIComponent,
+        }),
+      ).toMatchObject({ "user@host": "val ue" });
+    });
+
+    it("should apply filter after decodeName", () => {
+      expect(
+        parse("user%40a=1;user%40b=2", {
+          decodeName: decodeURIComponent,
+          filter: (key) => key === "user@a",
+        }),
+      ).toEqual({ "user@a": "1" });
+    });
+  });
+
+  describe('with "filter" option', () => {
     it("parse filter key", () => {
       expect(
         parse("a=1;b=2", {

--- a/test/cookie-parse.test.ts
+++ b/test/cookie-parse.test.ts
@@ -86,7 +86,6 @@ describe("cookie.parse(str, options)", () => {
         }),
       ).toMatchObject({ foo: "bar" });
     });
-
   });
 
   describe('with "decodeName" option', () => {
@@ -112,6 +111,14 @@ describe("cookie.parse(str, options)", () => {
           decodeName: decodeURIComponent,
         }),
       ).toMatchObject({ "user@host": "val ue" });
+    });
+
+    it("should propagate errors from decodeName", () => {
+      expect(() =>
+        parse("bad%ZZname=bar", {
+          decodeName: decodeURIComponent,
+        }),
+      ).toThrow(URIError);
     });
 
     it("should apply filter after decodeName", () => {


### PR DESCRIPTION
## Description

Adds an optional `decodeName` function to `CookieParseOptions` that decodes cookie **names** during parsing.

The existing `decode` option only applies to cookie values. Cookie names are returned as raw strings from the `Cookie` header. Browsers may URL-encode special characters in cookie names (e.g. `@` → `%40`), but server-side consumers often look up cookies by the decoded name — causing silent lookup failures.

### Example

```ts
import { parse } from 'cookie-es'

// Before: name stays encoded, lookup by decoded name fails
parse('user%40host=token')
// → { 'user%40host': 'token' }

// After: names are decoded
parse('user%40host=token', { decodeName: decodeURIComponent })
// → { 'user@host': 'token' }
```

### Motivation

AWS Amplify stores auth tokens in cookies keyed by username — e.g. `CognitoIdentityServiceProvider.<clientId>.user@test.local.idToken`. Browsers URL-encode the `@` as `%40` when sending the `Cookie` header.

Server-side, Amplify's [`TokenStore`](https://github.com/aws-amplify/amplify-js/blob/825d338021964a48ffab07d7b5961c5afa63a50e/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts#L214-L216) constructs the lookup key with the raw (decoded) username, then reads it via [`createKeyValueStorageFromCookieStorageAdapter`](https://github.com/aws-amplify/amplify-js/blob/825d338021964a48ffab07d7b5961c5afa63a50e/packages/aws-amplify/src/adapter-core/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts), which delegates to the framework's cookie getter. In h3/Nitro apps, that getter uses `cookie-es`'s `parse()` — which doesn't decode names, so the lookup silently returns `undefined` and the user appears unauthenticated.

### Changes

- **`src/cookie/types.ts`** — `decodeName` option on `CookieParseOptions`, note on `filter` interaction
- **`src/cookie/parse.ts`** — Apply `decodeName` to raw key before `filter` (2-line change)
- **`test/cookie-parse.test.ts`** — 5 tests: decode, no-op, independent from value decode, error propagation, filter interaction

### Design decisions

- `decodeName` is applied **before** `filter`, so filter receives the decoded name
- Errors propagate (not caught) — same contract as a user-provided `decode` per the existing JSDoc: *"If you provide your own encode/decode scheme you must ensure errors are appropriately handled"*
- Fully backward compatible — no behavior change when `decodeName` is not set