### PR TITLE
fix(set-cookie): do not let unknown attributes overwrite name and value

### DIFF
--- a/src/set-cookie/parse.ts
+++ b/src/set-cookie/parse.ts
@@ -145,7 +145,14 @@ export function parseSetCookie(
         }
         default: {
           const attrLower = attr.toLowerCase();
-          if (attrLower && !(attrLower in _nullProto)) {
+          // `name` and `value` hold the cookie pair itself and must not be
+          // overwritten by an unrecognized attribute of the same name.
+          if (
+            attrLower &&
+            attrLower !== "name" &&
+            attrLower !== "value" &&
+            !(attrLower in _nullProto)
+          ) {
             setCookie[attrLower] = val;
           }
         }

--- a/test/set-cookie-parser.test.ts
+++ b/test/set-cookie-parser.test.ts
@@ -263,6 +263,17 @@ describe("parseSetCookie", () => {
     });
   });
 
+  it("should not let unknown attributes overwrite the cookie name and value", () => {
+    expect(parseSetCookie("foo=bar; name=evil; value=evil")).toStrictEqual({
+      name: "foo",
+      value: "bar",
+    });
+    expect(parseSetCookie("foo=bar; Name=evil; VALUE=evil")).toStrictEqual({
+      name: "foo",
+      value: "bar",
+    });
+  });
+
   it("should decode values by default", () => {
     expect(parseSetCookie("foo=hello%20world")).toStrictEqual({
       name: "foo",


### PR DESCRIPTION
A `Set-Cookie` header carrying an attribute literally called `name` or `value` corrupts the parsed cookie pair, because the `default` branch writes every unrecognized attribute onto the same object that holds `name` and `value`:

```js
parseSetCookie("foo=bar; name=evil")
//=> { name: "evil", value: "bar" }   // expected name: "foo"

parseSetCookie("foo=bar; value=evil")
//=> { name: "foo", value: "evil" }   // expected value: "bar"
```

The result is not just wrong, it is attacker-controlled: `name` and `value` are the two fields every consumer reads, so a header that survives an upstream proxy or a cookie set from a less-trusted subdomain can silently rename a cookie or swap its value. Anything that parses and then re-serializes — a proxy, a cookie jar, a session middleware — will emit the substituted pair.

The `default` branch already guards `__proto__` and `constructor` via the `_nullProto` check, so the intent to keep the attribute bag from clobbering structure is there; `name` and `value` are the two remaining keys the object owns outright, and they were simply not covered.

The fix skips those two keys, matching the existing guard style. Case is handled by the same `toLowerCase()` the branch already applies, so `Name=` and `VALUE=` are covered too. Every other unknown attribute still lands on the object exactly as before, and the recognized attributes are untouched.

I checked the upstream sources this file is derived from — neither `set-cookie-parser` nor `cookie` is affected, since `set-cookie-parser` writes the pair after the attribute loop rather than before it.

### Validation

- New test `should not let unknown attributes overwrite the cookie name and value`, sitting next to the existing unknown-attribute test. It fails on `main` (`{ name: "evil" }`) and passes with the fix.
- Full suite: 135 passed.
- `oxlint` and `oxfmt --check` clean, `obuild` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unrecognized cookie attributes named `name` or `value` from overwriting the cookie’s primary name and value.
  - Preserved existing protection against unsafe attribute handling while continuing to support other unrecognized attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->